### PR TITLE
Fix the link to eg40 archive for bacteria

### DIFF
--- a/bacteria/archives.md
+++ b/bacteria/archives.md
@@ -2,6 +2,6 @@
 
 Archive of release 45 of EnsemblBacteria: [eg45-bacteria.ensembl.org](http://eg45-bacteria.ensembl.org) (Sep 2019)
 
-Archive of release 40 of EnsemblBacteria: [eg40-bacteria.ensembl.org](http://eg45-bacteria.ensembl.org) (July 2018)
+Archive of release 40 of EnsemblBacteria: [eg40-bacteria.ensembl.org](http://eg40-bacteria.ensembl.org) (July 2018)
 
 Archive of release 37 of EnsemblBacteria: [eg37-bacteria.ensembl.org](http://eg37-bacteria.ensembl.org) (October 2017)


### PR DESCRIPTION
Fixes an erroneous archive link to release-40 in bacteria