### PR TITLE
Modified annotation summary on rapid to main transfered sp.

### DIFF
--- a/metazoa/species/Athalia/Athalia_rosae/Athalia_rosae_gca917208135v1_annotation.md
+++ b/metazoa/species/Athalia/Athalia_rosae/Athalia_rosae_gca917208135v1_annotation.md
@@ -1,9 +1,5 @@
 **Annotation**
 ----------
 
-The annotation presented is derived from annotation submitted to
-[INSDC](http://www.insdc.org) with the assembly accession [GCA\_917208135.1](http://www.ebi.ac.uk/ena/data/view/GCA_917208135.1).
-
-Ensembl Metazoa displaying genes imported from [NCBI RefSeq](https://www.ncbi.nlm.nih.gov/genome/annotation_euk/Athalia_rosae/103) annotation release v103.
-Small RNA features, protein features, BLAST hits and cross-references have been
-computed by [Ensembl Metazoa](https://metazoa.ensembl.org/info/genome/annotation/index.html).
+Ensembl Metazoa displaying geneset built by [Ensembl GeneBuild](https://rapid.ensembl.org/info/genome/genebuild/full_genebuild.html) 
+and imported from [Ensembl Rapid](https://rapid.ensembl.org/Athalia_rosae_GCA_917208135.1/).

--- a/metazoa/species/Bombus/Bombus_terrestris/Bombus_terrestris_gca910591885v2_annotation.md
+++ b/metazoa/species/Bombus/Bombus_terrestris/Bombus_terrestris_gca910591885v2_annotation.md
@@ -1,9 +1,5 @@
 **Annotation**
 ----------
 
-The annotation presented is derived from annotation submitted to
-[INSDC](http://www.insdc.org) with the assembly accession [GCA\_910591885.1](http://www.ebi.ac.uk/ena/data/view/GCA_910591885.1).
-
-Ensembl Metazoa displaying genes imported from [NCBI RefSeq](https://www.ncbi.nlm.nih.gov/genome/annotation_euk/Bombus_terrestris/103) annotation release v103.
-Small RNA features, protein features, BLAST hits and cross-references have been
-computed by [Ensembl Metazoa](https://metazoa.ensembl.org/info/genome/annotation/index.html).
+Ensembl Metazoa displaying geneset built by [Ensembl GeneBuild](https://rapid.ensembl.org/info/genome/genebuild/full_genebuild.html)
+and imported from [Ensembl Rapid](https://rapid.ensembl.org/Bombus_terrestris_GCA_910591885.2/).

--- a/metazoa/species/Melitaea/Melitaea_cinxia/Melitaea_cinxia_gca905220565v1_annotation.md
+++ b/metazoa/species/Melitaea/Melitaea_cinxia/Melitaea_cinxia_gca905220565v1_annotation.md
@@ -1,9 +1,5 @@
 **Annotation**
 ----------
 
-The annotation presented is derived from annotation submitted to
-[INSDC](http://www.insdc.org) with the assembly accession [GCA\_905220565.1](http://www.ebi.ac.uk/ena/data/view/GCA_905220565.1).
-
-Ensembl Metazoa displaying genes imported from [NCBI RefSeq](https://www.ncbi.nlm.nih.gov/genome/annotation_euk/Melitaea_cinxia/100) annotation release v100.
-Small RNA features, protein features, BLAST hits and cross-references have been
-computed by [Ensembl Metazoa](https://metazoa.ensembl.org/info/genome/annotation/index.html).
+Ensembl Metazoa displaying geneset built by [Ensembl GeneBuild](https://rapid.ensembl.org/info/genome/genebuild/full_genebuild.html)
+and imported from [Ensembl Rapid](https://rapid.ensembl.org/Melitaea_cinxia_GCA_905220565.1/).


### PR DESCRIPTION
Small change required to update annotation summary:

As part of ensembl metazoa e110 handover, three species:

- Athalia rosae
- Bombus terrestris
- Melitaea cinxia

These were obtained directly from rapid release. These species required changes to the annotation summary, which was not from RefSeq as previously stated. 

URLs to each species rapid release species landing page included. 