### PR TITLE
Restore broken VectorBase URLs for EnsMetazoa e110

### DIFF
--- a/metazoa/species/Aedes/Aedes_albopictus/Aedes_albopictus_about.md
+++ b/metazoa/species/Aedes/Aedes_albopictus/Aedes_albopictus_about.md
@@ -18,4 +18,4 @@ from the Center for Disease Control and Prevention of Guangdong
 Province, China where it has been in culture since 1981.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/aedes-albopictus "Tendency to inhabit/rest in outdoor areas.")
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_001444175.1 "Tendency to inhabit/rest in outdoor areas.")

--- a/metazoa/species/Anopheles/Anopheles_albimanus/Anopheles_albimanus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_albimanus/Anopheles_albimanus_about.md
@@ -47,4 +47,4 @@ performed prior to genome sequencing. For more details [click
 here.](http://www.mr4.org/MR4ReagentsSearch/livingMosquitoes/MRA-126.aspx)
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-albimanus "Tendency to inhabit/rest in outdoor areas.")
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000349125.2 "Tendency to inhabit/rest in outdoor areas.")

--- a/metazoa/species/Anopheles/Anopheles_arabiensis/Anopheles_arabiensis_about.md
+++ b/metazoa/species/Anopheles/Anopheles_arabiensis/Anopheles_arabiensis_about.md
@@ -66,4 +66,4 @@ has undergone isofemale selection, and is available from the [BEI
 resource](https://www.beiresources.org) center.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-arabiensis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000349185.1)

--- a/metazoa/species/Anopheles/Anopheles_atroparvus/Anopheles_atroparvus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_atroparvus/Anopheles_atroparvus_about.md
@@ -55,4 +55,4 @@ to genome sequencing. For more details [click
 here](https://www.beiresources.org/Catalog/BEIVectors/MRA-493.aspx).
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-atroparvus)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000473505.1)

--- a/metazoa/species/Anopheles/Anopheles_atroparvus/Anopheles_atroparvus_assembly.md
+++ b/metazoa/species/Anopheles/Anopheles_atroparvus/Anopheles_atroparvus_assembly.md
@@ -6,7 +6,7 @@ hybridization of genomic scaffolds and synteny information from the
 paper [\"Partial-arm translocations in evolution of malaria mosquitoes
 revealed by high- coverage physical mapping of the Anopheles atroparvus
 genome\", Artemov et al, BMC
-Genomics](https://www.vectorbase.org/publications/partial-arm-translocations-evolution-malaria-mosquitoes-revealed-high-coverage-physical).
+Genomics](https://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-018-4663-4).
 The assembly differs from the *Aatre2* version by the inclusion of
 spacer sequences between scaffolds, and the presence of a 1MB gap of
 chromosome 2L. No sequences have changed, and the order of assembly

--- a/metazoa/species/Anopheles/Anopheles_christyi/Anopheles_christyi_about.md
+++ b/metazoa/species/Anopheles/Anopheles_christyi/Anopheles_christyi_about.md
@@ -13,4 +13,4 @@ Originally isolated from wild individuals collected in Kenya (Kikuyu,
 College London). There is no colony.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-christyi "Tendency to inhabit/rest in outdoor areas.")
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000349165.1 "Tendency to inhabit/rest in outdoor areas.")

--- a/metazoa/species/Anopheles/Anopheles_coluzzii/Anopheles_coluzzii_about.md
+++ b/metazoa/species/Anopheles/Anopheles_coluzzii/Anopheles_coluzzii_about.md
@@ -24,4 +24,4 @@ gambiae* M Mali-NIH colony is currently maintained from the [BEI
 resources](https://www.beiresources.org) web portal.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-coluzzii)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000150765.1)

--- a/metazoa/species/Anopheles/Anopheles_coluzzii/Anopheles_coluzzii_ngousso_about.md
+++ b/metazoa/species/Anopheles/Anopheles_coluzzii/Anopheles_coluzzii_ngousso_about.md
@@ -25,4 +25,4 @@ colony is partially inbred, and has been used extensively in
 experimental infection studies.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-coluzzii)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_004136515.2)

--- a/metazoa/species/Anopheles/Anopheles_culicifacies/Anopheles_culicifacies_about.md
+++ b/metazoa/species/Anopheles/Anopheles_culicifacies/Anopheles_culicifacies_about.md
@@ -80,4 +80,4 @@ village, May 2010), mosquitoes were donated by Mohammad Oshagi and Igor
 Sharakhov (Virginia Tech). There is no colony.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-culicifacies)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000473375.1)

--- a/metazoa/species/Anopheles/Anopheles_darlingi/Anopheles_darlingi_about.md
+++ b/metazoa/species/Anopheles/Anopheles_darlingi/Anopheles_darlingi_about.md
@@ -58,7 +58,7 @@ Coari. Gravid females were allowed to spawn and DNA extracted from 4th
 stage larvae.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-darlingi)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000211455.3)
 
 Picture credit (public domain): [Wikimedia
 Commons](http://commons.wikimedia.org/wiki/File:Anophelesdarlingi.jpg)

--- a/metazoa/species/Anopheles/Anopheles_dirus/Anopheles_dirus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_dirus/Anopheles_dirus_about.md
@@ -66,4 +66,4 @@ selection, and is available from [BEI
 resources](https://www.beiresources.org).
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-dirus)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000349145.1)

--- a/metazoa/species/Anopheles/Anopheles_epiroticus/Anopheles_epiroticus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_epiroticus/Anopheles_epiroticus_about.md
@@ -14,4 +14,4 @@ donned by Lien Tran and Martin Donnelly (Liverpool School of Tropical
 Medicine)
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-epiroticus "A sequence of computational tasks or actions that carry out a specific function.")
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000349105.1 "A sequence of computational tasks or actions that carry out a specific function.")

--- a/metazoa/species/Anopheles/Anopheles_farauti/Anopheles_farauti_about.md
+++ b/metazoa/species/Anopheles/Anopheles_farauti/Anopheles_farauti_about.md
@@ -90,4 +90,4 @@ sequencing. This tsrain is available from [BEI
 resources.](https://www.beiresources.org)
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-farauti)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000473445.2)

--- a/metazoa/species/Anopheles/Anopheles_funestus/Anopheles_funestus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_funestus/Anopheles_funestus_about.md
@@ -65,4 +65,4 @@ selection. The strain is available from [BEI
 resources](https://www.beiresources.org).
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-funestus)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_003951495.1)

--- a/metazoa/species/Anopheles/Anopheles_gambiae/Anopheles_gambiae_about.md
+++ b/metazoa/species/Anopheles/Anopheles_gambiae/Anopheles_gambiae_about.md
@@ -107,7 +107,7 @@ diagnostic of the *A. gambiae M* and *S* molecular forms. The last known
 isolate of the *A. gambiae PEST* colony was lost in about 2005.
 
 Source:
-[VectorBase](http://https://www.vectorbase.org/organisms/anopheles-gambiae)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000005575.2)
 
 Picture credit (public domain): [James
 Gathany](http://phil.cdc.gov/phil/details_linked.asp?pid=1354) (CDC)

--- a/metazoa/species/Anopheles/Anopheles_gambiae/Anopheles_gambiae_annotation.md
+++ b/metazoa/species/Anopheles/Anopheles_gambiae/Anopheles_gambiae_annotation.md
@@ -8,4 +8,4 @@ gene prediction using the Ensembl system. Prediction utilised alignments
 of dipteran and other protein sets to the genome and generation of
 GeneWise models, alignment and gene prediction based on Anopheles ESTs,
 and selected *ab initio* predictions. More details can be found in
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-gambiae/pest).
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000005575.2).

--- a/metazoa/species/Anopheles/Anopheles_gambiae/Anopheles_gambiae_assembly.md
+++ b/metazoa/species/Anopheles/Anopheles_gambiae/Anopheles_gambiae_assembly.md
@@ -48,9 +48,5 @@ of the true genome size ([Sharakhova et al.
 addition of the mitochondrial genome (L20934, 16,655 bp) which includes
 13 protein-coding and 24 ncRNAs (22 tRNA and 2 rRNA genes).**
 
-Additional notes compiled on known assembly issues from the initial
-VectorBase project can be found
-[here](https://www.vectorbase.org/content/notes-scaffolds-anopheles-gambiae-pest-whole-genome-shotgun-assembly).
-
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-gambiae/pest/agamp4).
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000005575.2)

--- a/metazoa/species/Anopheles/Anopheles_maculatus/Anopheles_maculatus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_maculatus/Anopheles_maculatus_about.md
@@ -76,4 +76,4 @@ performed on preserved females donated by Lee Han Lim. No colony is
 available.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-maculatus)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000473185.1)

--- a/metazoa/species/Anopheles/Anopheles_melas/Anopheles_melas_about.md
+++ b/metazoa/species/Anopheles/Anopheles_melas/Anopheles_melas_about.md
@@ -66,4 +66,4 @@ North, 9.828 East, Campo, 2010), mosquitoes were donated by Carlo
 Costantini. The colony was not subject to isofemale selection.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-melas)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000473525.2)

--- a/metazoa/species/Anopheles/Anopheles_merus/Anopheles_merus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_merus/Anopheles_merus_about.md
@@ -50,4 +50,4 @@ isofemale selection was performed prior to genome sequencing. This
 strain is available from [BEI resources](http://www.beiresources.org/).
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-merus)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000473845.2)

--- a/metazoa/species/Anopheles/Anopheles_minimus/Anopheles_minimus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_minimus/Anopheles_minimus_about.md
@@ -77,4 +77,4 @@ done prior to genome sequencing. This strain is available form [BEI
 resources](http://www.beiresources.org).
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-minimus)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000349025.1)

--- a/metazoa/species/Anopheles/Anopheles_quadriannulatus/Anopheles_quadriannulatus_about.md
+++ b/metazoa/species/Anopheles/Anopheles_quadriannulatus/Anopheles_quadriannulatus_about.md
@@ -14,4 +14,4 @@ strain is a synonym for the *SANGQUA* strain (this strain is available
 from [BEI resources](https://www.beiresources.org)).
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-quadriannulatus)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000349065.1)

--- a/metazoa/species/Anopheles/Anopheles_sinensis/Anopheles_sinensis_about.md
+++ b/metazoa/species/Anopheles/Anopheles_sinensis/Anopheles_sinensis_about.md
@@ -66,4 +66,4 @@ genomes of 16 Anopheles mosquitoes. Science. Published Online November
 27 2014
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-sinensis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000472065.2)

--- a/metazoa/species/Anopheles/Anopheles_sinensis/Anopheles_sinensis_china_about.md
+++ b/metazoa/species/Anopheles/Anopheles_sinensis/Anopheles_sinensis_china_about.md
@@ -63,4 +63,4 @@ parasites.\", Zhou et al,
 ([PMID:24438588](https://www.ncbi.nlm.nih.gov/pubmed/?term=24438588)).
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-sinensis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000441895.2)

--- a/metazoa/species/Anopheles/Anopheles_stephensi/Anopheles_stephensi_about.md
+++ b/metazoa/species/Anopheles/Anopheles_stephensi/Anopheles_stephensi_about.md
@@ -77,4 +77,4 @@ Neafsey et al (121 authors). 2015. Highly evolvable malaria vectors:
 November 27 2014
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-stephensi)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000349045.1)

--- a/metazoa/species/Anopheles/Anopheles_stephensi/Anopheles_stephensi_indian_about.md
+++ b/metazoa/species/Anopheles/Anopheles_stephensi/Anopheles_stephensi_indian_about.md
@@ -83,4 +83,4 @@ vector mosquito, Anopheles stephensi* . Genome Biol. 2014 Sep
 23;15(9):459.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/anopheles-stephensi)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000300775.2)

--- a/metazoa/species/Biomphalaria/Biomphalaria_glabrata/Biomphalaria_glabrata_about.md
+++ b/metazoa/species/Biomphalaria/Biomphalaria_glabrata/Biomphalaria_glabrata_about.md
@@ -36,4 +36,4 @@ for genome sequencing at The Genomics Institute (TGI), Washington
 University, St Louis MO.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/biomphalaria-glabrata)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000457365.1)

--- a/metazoa/species/Cimex/Cimex_lectularius/Cimex_lectularius_about.md
+++ b/metazoa/species/Cimex/Cimex_lectularius/Cimex_lectularius_about.md
@@ -16,6 +16,6 @@ material was produced from animals after five generations of
 single pair matings.
 
 Sources:
-* [VectorBase](https://www.vectorbase.org/organisms/cimex-lectularius)
+* [VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000648675.3)
 * [NCBI BioSample SAMN02649412](https://www.ncbi.nlm.nih.gov/biosample/SAMN02649412/)
 * [BCM-HGSC Bed Bug Genome Project](https://www.hgsc.bcm.edu/arthropods/bed-bug-genome-project)

--- a/metazoa/species/Glossina/Glossina_austeni/Glossina_austeni_about.md
+++ b/metazoa/species/Glossina/Glossina_austeni/Glossina_austeni_about.md
@@ -13,4 +13,4 @@ Trypanosomosis Research Institute (TTRI) laboratories in Tanga,
 Tanzania.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/glossina-austeni)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000688735.1)

--- a/metazoa/species/Glossina/Glossina_brevipalpis/Glossina_brevipalpis_about.md
+++ b/metazoa/species/Glossina/Glossina_brevipalpis/Glossina_brevipalpis_about.md
@@ -13,4 +13,4 @@ Sequenced strain originating from colony maintained in IAEA laboratories
 in Seibersdorf, Austria.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/glossina-brevipalpis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000671755.1)

--- a/metazoa/species/Glossina/Glossina_fuscipes/Glossina_fuscipes_gca014805625v1_about.md
+++ b/metazoa/species/Glossina/Glossina_fuscipes/Glossina_fuscipes_gca014805625v1_about.md
@@ -7,4 +7,4 @@ well as Gabon, Cameroon and the southern part of Chad. Vector of
 *Trypanosoma brucei rhodesiense* in East Africa.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/glossina-fuscipes)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_014805625.1)

--- a/metazoa/species/Glossina/Glossina_morsitans/Glossina_morsitans_about.md
+++ b/metazoa/species/Glossina/Glossina_morsitans/Glossina_morsitans_about.md
@@ -33,4 +33,4 @@ in the [Aksoy
 lab](http://medicine.yale.edu/lab/aksoy/ "http://medicine.yale.edu/labs/aksoy/").
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/glossina-morsitans)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_001077435.1)

--- a/metazoa/species/Glossina/Glossina_pallidipes/Glossina_pallidipes_about.md
+++ b/metazoa/species/Glossina/Glossina_pallidipes/Glossina_pallidipes_about.md
@@ -14,4 +14,4 @@ Sequenced strain originating from colony maintained in IAEA laboratories
 in Seibersdorf, Austria
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/glossina-pallidipes)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000688715.1)

--- a/metazoa/species/Glossina/Glossina_palpalis/Glossina_palpalis_about.md
+++ b/metazoa/species/Glossina/Glossina_palpalis/Glossina_palpalis_about.md
@@ -15,4 +15,4 @@ Sequenced strain originating from colony maintained in IAEA laboratories
 in Seibersdorf, Austria
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/glossina-palpalis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000818775.1)

--- a/metazoa/species/Ixodes/Ixodes_scapularis/Ixodes_scapularis_about.md
+++ b/metazoa/species/Ixodes/Ixodes_scapularis/Ixodes_scapularis_about.md
@@ -24,7 +24,7 @@ isolates. Dr. D. Sonenshine at Old Dominion University also maintains a
 satellite colony of the Wikel strain.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/ixodes-scapularis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000208615.1)
 
 Picture credit (public domain): [Scott
 Bauer](http://commons.wikimedia.org/wiki/File:Adult_deer_tick.jpg)

--- a/metazoa/species/Ixodes/Ixodes_scapularis/Ixodes_scapularis_gca016920785v2_about.md
+++ b/metazoa/species/Ixodes/Ixodes_scapularis/Ixodes_scapularis_gca016920785v2_about.md
@@ -11,7 +11,7 @@ disease, transmitting the pathogenic bacterium *Borrelia burgdorfei*.
 
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/ixodes-scapularis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_016920785.2)
 
 Picture credit (public domain): [Scott
 Bauer](http://commons.wikimedia.org/wiki/File:Adult_deer_tick.jpg)

--- a/metazoa/species/Ixodes/Ixodes_scapularis/Ixodes_scapularis_ise6_about.md
+++ b/metazoa/species/Ixodes/Ixodes_scapularis/Ixodes_scapularis_ise6_about.md
@@ -25,7 +25,7 @@ phenotype", Oliver et al, Exp Appl Acarol. 2015 Jul; 66(3): 427--442.
 doi: 10.1007/s10493-015-9908-1).
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/ixodes-scapularis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_002892825.2)
 
 Picture credit (public domain): [Scott
 Bauer](http://commons.wikimedia.org/wiki/File:Adult_deer_tick.jpg)

--- a/metazoa/species/Leptotrombidium/Leptotrombidium_deliense/Leptotrombidium_deliense_about.md
+++ b/metazoa/species/Leptotrombidium/Leptotrombidium_deliense/Leptotrombidium_deliense_about.md
@@ -34,7 +34,7 @@ laboratory strain. It was used for the generation of the VectorBase
 reference assembly LdelU1
 
 Sources:
-[Vectorbase.org](https://www.vectorbase.org/organisms/leptotrombidium-deliense)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_003675905.1)
 and [Wikipedia](https://en.wikipedia.org/wiki/Leptotrombidium).
 
 Picture credit: Dr Kittipong Chaisiri, Mahidol University

--- a/metazoa/species/Lutzomyia/Lutzomyia_longipalpis/Lutzomyia_longipalpis_about.md
+++ b/metazoa/species/Lutzomyia/Lutzomyia_longipalpis/Lutzomyia_longipalpis_about.md
@@ -32,4 +32,4 @@ species. This knowledge is vital to understand the epidemiology and
 control of this neglected disease in South and Central America
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/lutzomyia-longipalpis)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000265325.1)

--- a/metazoa/species/Musca/Musca_domestica/Musca_domestica_about.md
+++ b/metazoa/species/Musca/Musca_domestica/Musca_domestica_about.md
@@ -9,4 +9,4 @@ Common house fly, a comparator species for the tsetse project.
 *Musca domestica* strain maintained by Jeff Scott At Cornell University.
 
 Souce:
-[VectorBase](https://www.vectorbase.org/organisms/musca-domestica)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000371365.1)

--- a/metazoa/species/Phlebotomus/Phlebotomus_papatasi/Phlebotomus_papatasi_about.md
+++ b/metazoa/species/Phlebotomus/Phlebotomus_papatasi/Phlebotomus_papatasi_about.md
@@ -15,4 +15,4 @@ over time, experiencing several bottlenecks. The colony was expanded
 from a small number of flies at the University of Notre Dame.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/phlebotomus-papatasi)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000262795.1)

--- a/metazoa/species/Rhodnius/Rhodnius_prolixus/Rhodnius_prolixus_annotation.md
+++ b/metazoa/species/Rhodnius/Rhodnius_prolixus/Rhodnius_prolixus_annotation.md
@@ -2,7 +2,7 @@ Annotation
 ----------
 
 The annotation of the *Rhodnius prolixus* genome has been conducted by
-[VectorBase](http://www.vectorbase.org/Rhodnius_prolixus/Info/Index).
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_000181055.3).
 Genes were predicted using the Ensembl pipeline, which combines the
 results from *ab initio* predictions from Genscan and SNAP, alignments
 of dipteran and other protein sets, and *R. prolixus* ESTs. The geneset

--- a/metazoa/species/Stomoxys/Stomoxys_calcitrans/Stomoxys_calcitrans_about.md
+++ b/metazoa/species/Stomoxys/Stomoxys_calcitrans/Stomoxys_calcitrans_about.md
@@ -11,4 +11,4 @@ undertaken on pooled multiple male (F7 generation from inbred line
 *8C7A2A5H3J4*) individual DNA isolates.
 
 Source:
-[VectorBase](https://www.vectorbase.org/organisms/stomoxys-calcitrans)
+[VectorBase](https://veupathdb.org/veupathdb/app/search/dataset/AllDatasets/result?filterTerm=GCA_001015335.1)


### PR DESCRIPTION
VEuPathDB has raised that the VectorBase organism URLs we have in our static content are broken (they changed the URL "format" without notifying us). This PR fixes that issue, together with a couple of additional links that were also broken (one could not be restored, so the text it was integrated into has been removed as well).