### PR TITLE
Add image derived from Glycine soja species URL

### DIFF
--- a/plants/images/species/Glycine_soja_GCA_004193775.2rs.png
+++ b/plants/images/species/Glycine_soja_GCA_004193775.2rs.png
@@ -1,0 +1,1 @@
+Glycine_soja.png


### PR DESCRIPTION
This PR adds a species image (symlink) for Glycine soja, with the file name derived from its species URL.

With this image added, gene gain/loss trees show an image for the species tree node representing this species.

Example on Plants RC site: http://rc-plants.ensembl.org/Arabidopsis_thaliana/Gene/SpeciesTree?g=AT1G07820;r=1:2421089-2422066
Example on Plants sandbox: http://wp-np2-25.ebi.ac.uk:5098/Arabidopsis_thaliana/Gene/SpeciesTree?g=AT1G07820;r=1:2421089-2422066

Related ticket: [ENSWEB-6912](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6912)
