### PR TITLE
Delete symlink named after wrong Glycine soja URL

### DIFF
--- a/plants/images/species/Glycine_soja_GCA_004193775.2rs.png
+++ b/plants/images/species/Glycine_soja_GCA_004193775.2rs.png
@@ -1,1 +1,0 @@
-Glycine_soja.png


### PR DESCRIPTION
This PR effectively reverts the previous PR #126.

The issue this file was intended to address was fixed by [staging patch 635](https://github.com/Ensembl/staging-patches/pull/635).

