### PR TITLE
Fix: Single species - swap annotation source from Genbank to RefSeq

### DIFF
--- a/metazoa/species/Anopheles/Anopheles_funestus/Anopheles_funestus_gca943734845v1rs_annotation.md
+++ b/metazoa/species/Anopheles/Anopheles_funestus/Anopheles_funestus_gca943734845v1rs_annotation.md
@@ -1,9 +1,9 @@
 **Annotation**
 ----------
 
-Ensembl Metazoa displaying genes imported from GenBank entry linked to the assembly with accession [GCA\_943734845.1](http://www.ebi.ac.uk/ena/data/view/GCA_943734845.1).
+The annotation presented is derived from annotation submitted to [INSDC](http://www.insdc.org) with the assembly accession [GCA\_943734845.1](http://www.ebi.ac.uk/ena/data/view/GCA_943734845.1).
 
-Genomic annotation was deposited along with assembly deposited to the INSDC by [Wellcome Sanger Institute](https://www.sanger.ac.uk/).
+Ensembl Metazoa displaying genes imported from [NCBI RefSeq](https://www.ncbi.nlm.nih.gov/refseq/annotation_euk/Anopheles_funestus/100/) Annotation Release 100
 
 Small RNA features, protein features, BLAST hits and cross-references have been
-computed by [Ensembl Metazoa](https://metazoa.ensembl.org/info/genome/annotation/index.html).
+computed by [Ensembl Metazoa](https://metazoa.ensembl.org/info/genome/annotation/index.html)


### PR DESCRIPTION

- Small change required to correctly attribute original source of annotation for Anopheles funestus. 

This species was absorbed via sync with VEuPath, which was originally imported from RefSeq. This information was obscured at time of static generation. 