### PR TITLE
Update other/planned changes to Whatsnew MD - Metazoa e114

### DIFF
--- a/metazoa/whatsnew.md
+++ b/metazoa/whatsnew.md
@@ -1,5 +1,5 @@
 - **Updated gene sets**
-  - _Drosophila melanogaster_ (Fruit fly,  GCA\_000001215.4) - New annotation (Flybase Release 6.54) of assembly GCA\_000001215.4. 
+  - _Drosophila melanogaster_ (Fruit fly,  GCA\_000001215.4) - New annotation (Flybase Release 6.54) of assembly GCA\_000001215.4 
   - _Anopheles albimanus_ (Mosquito, GCA\_000349125.2)
   - _Anopheles gambiae_ (African malaria mosquito, GCA\_000005575.1)
   - _Anopheles quadriannulatus_ (Mosquito, GCA\_000349065.1) (previously existing geneset preseved under the original name)
@@ -14,7 +14,7 @@
   - _Anopheles gambiae_ (African malaria mosquito, GCA\_943734735.2)
   - _Biomphalaria glabrata_ (Bloodfluke planorb, GCA\_947242115.1)
   - _Bombyx mori_ (Silk Moth, GCA\_030269925.2)
-  - _Magallana gigas_ (Bivalves, GCA\_963853765.1) (former _Crassostrea gigas_) - New RefSeq annotation was added for GCA\_902806645.1.
+  - _Magallana gigas_ (Bivalves, GCA\_963853765.1) (former _Crassostrea gigas_) - New RefSeq annotation was added for GCA\_902806645.1
 
 - **Assembly and gene set data updated**
   - _Aedes albopictus_ (Asian tiger mosquito, GCA\_035046485.1)
@@ -39,21 +39,21 @@
 - **Other updates**
   - _Anopheles coluzzi_ (Mosquito) - Older GCA\_000150765.1 genome now removed
   - _Aedes albopictus_ (Asian tiger mosquito) -  Older GCA\_001444175.1 now removed
-  - _Bombus terrestris_ (Buff-tailed bumble-bee) - Compara reference genome updated to GCA\_910591885.2 (Metazoa & Protostome protein trees), older GCA\_000214255.1 now removed.
+  - _Bombus terrestris_ (Buff-tailed bumble-bee) - Compara reference genome updated to GCA\_910591885.2 (Metazoa & Protostome protein trees), older GCA\_000214255.1 now removed
   - _Haemaphysalis longicornis_ (Longhorned tick) -  Older GCA\_013339765.1 now removed
 
 - **Planned updates:**
     - Release 62:
-      - Compara _Drosophila_ pangenome:
-        - Existing pangenome species will be updated to latest references where available. 
-        - Replaced older references will be dropped.
+      - Compara _Drosophilidae_ pangenome:
+        - Existing pangenome species will be updated to latest references where available
+        - Replaced older references will be dropped
         - Additional species to be added:
-           - _Drosophila montana_
-           - _Drosophila nasuta_
-           - _Drosophila novamexicana_
-           - _Drosophila serrata_
-           - _Drosophila sulfurigaster albostrigata_
-           - _Drosophila tropicalis_
+           - _Drosophila montana_ (GCA\_035044405.1)
+           - _Drosophila nasuta_ (GCA\_023558535.2)
+           - _Drosophila novamexicana_ (GCA\_003285875.3)
+           - _Drosophila serrata_ (GCA\_002093755.2)
+           - _Drosophila sulfurigaster albostrigata_ (GCA\_023558435.2)
+           - _Drosophila tropicalis_ (GCA\_018151085.1)
 
 - **Updated BioMarts for all gene and variation data**
 - **Updated pan-taxonomic gene trees and homologies**

--- a/metazoa/whatsnew.md
+++ b/metazoa/whatsnew.md
@@ -18,7 +18,7 @@
 
 - **Assembly and gene set data updated**
   - _Aedes albopictus_ (Asian tiger mosquito, GCA\_035046485.1)
-  - _Bombus terrestris_ (Buff-tailed bumble-bee) - Compara reference genome (Metazoa & Protostome protein trees) updated to newer GCA\_910591885.2 assembly (The older GCA\_000214255.1 was removed).
+  - _Bombus terrestris_ (Buff-tailed bumble-bee, GCA\_910591885.2)
   - _Haemaphysalis longicornis_ (Longhorned tick, GCA\_013339765.2)
   - _Hyalomma asiaticum_ (Tick, GCA\_013339685.2)
   - _Ixodes persulcatus_ (Taiga tick, GCA\_013358835.2)
@@ -37,9 +37,23 @@
   - _Platynereis dumerilii_ (Dumeril's clam worm, GCA\_026936325.1)
 
 - **Other updates**
-  - _Bombus terrestris_ (Buff-tailed bumble-bee) - the older GCA\_000214255.1 was removed
+  - _Anopheles coluzzi_ (Mosquito) - Older GCA\_000150765.1 genome now removed
+  - _Aedes albopictus_ (Asian tiger mosquito) -  Older GCA\_001444175.1 now removed
+  - _Bombus terrestris_ (Buff-tailed bumble-bee) - Compara reference genome updated to GCA\_910591885.2 (Metazoa & Protostome protein trees), older GCA\_000214255.1 now removed.
+  - _Haemaphysalis longicornis_ (Longhorned tick) -  Older GCA\_013339765.1 now removed
 
-- **Planned updates**
+- **Planned updates:**
+    - Release 62:
+      - Compara _Drosophila_ pangenome:
+        - Existing pangenome species will be updated to latest references where available. 
+        - Replaced older references will be dropped.
+        - Additional species to be added:
+           - _Drosophila montana_
+           - _Drosophila nasuta_
+           - _Drosophila novamexicana_
+           - _Drosophila serrata_
+           - _Drosophila sulfurigaster albostrigata_
+           - _Drosophila tropicalis_
 
 - **Updated BioMarts for all gene and variation data**
 - **Updated pan-taxonomic gene trees and homologies**


### PR DESCRIPTION
- Small shift in ordering of existing content
- Added information related to planned changes to Drosophila pangenome (EG62)
- Added missing genomes we had dropped as of 114. 
